### PR TITLE
Add defaultTreatment to SplitView

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.10.2 (October XX, 2023)
+ - Added `defaultTreatment` property to the `SplitView` object returned by the `split` and `splits` methods of the SDK manager (Related to issue https://github.com/splitio/javascript-commons/issues/225).
+ - Updated @splitsoftware/splitio-commons package to version 1.10.0 that includes vulnerability fixes, and adds the `defaultTreatment` property to the `SplitView` object.
+
 0.10.1 (September 22, 2023)
  - Updated @splitsoftware/splitio-commons package to version 1.9.1. This update removes the handler for 'unload' DOM events, that can prevent browsers from being able to put pages in the back/forward cache for faster back and forward loads (Related to issue https://github.com/splitio/javascript-client/issues/759).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio-commons": "1.9.1",
+        "@splitsoftware/splitio-commons": "1.10.0",
         "@types/google.analytics": "0.0.40",
         "unfetch": "^4.2.0"
       },
@@ -2836,9 +2836,9 @@
       "dev": true
     },
     "node_modules/@splitsoftware/splitio-commons": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.9.1.tgz",
-      "integrity": "sha512-+1lFUBj+Jgfd8l7nT49+rZodwgZXJ6c20+4PPb0O+iTmUZXHtYvfS2AK8A9j6QREubeccc6UMlfjH3SQVgwEbg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.10.0.tgz",
+      "integrity": "sha512-se4jrBr0wMYJCeOKOx8xfICNSyRM9fpKT/7BtPy5mJERqfDWS+hjMLH+PweBNgW6YJeG1c4F0j9lBUE5CwgPjw==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -13355,9 +13355,9 @@
       "dev": true
     },
     "@splitsoftware/splitio-commons": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.9.1.tgz",
-      "integrity": "sha512-+1lFUBj+Jgfd8l7nT49+rZodwgZXJ6c20+4PPb0O+iTmUZXHtYvfS2AK8A9j6QREubeccc6UMlfjH3SQVgwEbg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-1.10.0.tgz",
+      "integrity": "sha512-se4jrBr0wMYJCeOKOx8xfICNSyRM9fpKT/7BtPy5mJERqfDWS+hjMLH+PweBNgW6YJeG1c4F0j9lBUE5CwgPjw==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:ga-to-split-autorequire": "terser ./node_modules/@splitsoftware/splitio-commons/src/integrations/ga/autoRequire.js --mangle --output ./scripts/ga-to-split-autorequire.js",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "jest",
-    "test:e2e": "npm run test:e2e-logger && npm run test:e2e-offline && npm run test:e2e-online && npm run test:e2e-destroy && npm run test:e2e-errorCatching && npm run test:e2e-push && npm run test:e2e-gaIntegration && npm run test:e2e-consumer",
+    "test:e2e": "npm run test:e2e-logger && npm run test:e2e-offline && npm run test:e2e-online && npm run test:e2e-destroy && npm run test:e2e-errorCatching && npm run test:e2e-push && npm run test:e2e-consumer",
     "test:e2e-logger": "karma start karma/e2e.logger.karma.conf.js",
     "test:e2e-offline": "karma start karma/e2e.offline.karma.conf.js",
     "test:e2e-online": "karma start karma/e2e.online.karma.conf.js",
@@ -64,7 +64,7 @@
   "bugs": "https://github.com/splitio/javascript-browser-client/issues",
   "homepage": "https://github.com/splitio/javascript-browser-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio-commons": "1.9.1",
+    "@splitsoftware/splitio-commons": "1.10.0",
     "@types/google.analytics": "0.0.40",
     "unfetch": "^4.2.0"
   },

--- a/src/__tests__/browserSuites/manager.spec.js
+++ b/src/__tests__/browserSuites/manager.spec.js
@@ -39,7 +39,8 @@ export default async function (settings, fetchMock, assert) {
     'killed': mockSplits.splits[index].killed,
     'changeNumber': mockSplits.splits[index].changeNumber,
     'treatments': map(mockSplits.splits[index].conditions[0].partitions, partition => partition.treatment),
-    'configs': mockSplits.splits[index].configurations || {}
+    'configs': mockSplits.splits[index].configurations || {},
+    'defaultTreatment': mockSplits.splits[index].defaultTreatment
   });
 
   assert.equal(manager.split('non_existent'), null, 'Trying to get a manager.split() of a Split that does not exist returns null.');

--- a/src/__tests__/browserSuites/ready-promise.spec.js
+++ b/src/__tests__/browserSuites/ready-promise.spec.js
@@ -31,7 +31,7 @@ function assertGetTreatmentWhenReady(assert, client) {
 function assertGetTreatmentControlNotReady(assert, client) {
   consoleSpy.log.resetHistory();
   assert.equal(client.getTreatment('hierarchical_splits_test'), 'control', 'We should get control if client is not ready.');
-  assert.true(consoleSpy.log.calledWithExactly('[WARN]  splitio => getTreatment: the SDK is not ready, results may be incorrect. Make sure to wait for SDK readiness before using this method.'), 'Telling us that calling getTreatment would return CONTROL since SDK is not ready at this point.');
+  assert.true(consoleSpy.log.calledWithExactly('[WARN]  splitio => getTreatment: the SDK is not ready, results may be incorrect for feature flag hierarchical_splits_test. Make sure to wait for SDK readiness before using this method.'), 'Telling us that calling getTreatment would return CONTROL since SDK is not ready at this point.');
 }
 
 function assertGetTreatmentControlNotReadyOnDestroy(assert, client) {

--- a/src/__tests__/consumer/browser_consumer.spec.js
+++ b/src/__tests__/consumer/browser_consumer.spec.js
@@ -10,7 +10,7 @@ import { version } from '../../../package.json';
 import { SplitFactory, PluggableStorage } from '../../';
 
 const expectedSplitName = 'hierarchical_splits_testing_on';
-const expectedSplitView = { name: 'hierarchical_splits_testing_on', trafficType: 'user', killed: false, changeNumber: 1487277320548, treatments: ['on', 'off'], configs: {} };
+const expectedSplitView = { name: 'hierarchical_splits_testing_on', trafficType: 'user', killed: false, changeNumber: 1487277320548, treatments: ['on', 'off'], configs: {}, defaultTreatment: 'off' };
 
 const wrapperPrefix = 'PLUGGABLE_STORAGE_UT';
 const wrapperInstance = inMemoryWrapperFactory();

--- a/src/__tests__/consumer/browser_consumer_partial.spec.js
+++ b/src/__tests__/consumer/browser_consumer_partial.spec.js
@@ -10,7 +10,7 @@ import { applyOperations } from './wrapper-commands';
 import { SplitFactory, PluggableStorage } from '../../';
 
 const expectedSplitName = 'hierarchical_splits_testing_on';
-const expectedSplitView = { name: 'hierarchical_splits_testing_on', trafficType: 'user', killed: false, changeNumber: 1487277320548, treatments: ['on', 'off'], configs: {} };
+const expectedSplitView = { name: 'hierarchical_splits_testing_on', trafficType: 'user', killed: false, changeNumber: 1487277320548, treatments: ['on', 'off'], configs: {}, defaultTreatment: 'off' };
 
 const wrapperPrefix = 'PLUGGABLE_STORAGE_UT';
 const wrapperInstance = inMemoryWrapperFactory();

--- a/src/__tests__/offline/browser.spec.js
+++ b/src/__tests__/offline/browser.spec.js
@@ -181,10 +181,10 @@ tape('Browser offline mode', function (assert) {
 
     // Manager tests
     const expectedSplitView1 = {
-      name: 'testing_split', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['on'], configs: {}
+      name: 'testing_split', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['on'], configs: {}, defaultTreatment: 'control'
     };
     const expectedSplitView2 = {
-      name: 'testing_split_with_config', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['off'], configs: { off: '{ "color": "blue" }' }
+      name: 'testing_split_with_config', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['off'], configs: { off: '{ "color": "blue" }' }, defaultTreatment: 'control'
     };
     assert.deepEqual(manager.names(), ['testing_split', 'testing_split_with_config']);
     assert.deepEqual(manager.split('testing_split'), expectedSplitView1);
@@ -282,7 +282,7 @@ tape('Browser offline mode', function (assert) {
 
       // Manager tests
       const expectedSplitView3 = {
-        name: 'testing_split_with_config', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['nope'], configs: {}
+        name: 'testing_split_with_config', trafficType: 'localhost', killed: false, changeNumber: 0, treatments: ['nope'], configs: {}, defaultTreatment: 'control'
       };
       assert.deepEqual(manager.names(), ['testing_split', 'testing_split_2', 'testing_split_3', 'testing_split_with_config']);
       assert.deepEqual(manager.split('testing_split'), expectedSplitView1);

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -135,7 +135,8 @@ splitView = {
   changeNumber: 18294,
   configs: {
     off: '{"dimensions":"{\"height\":20,\"width\":40}"}'
-  }
+  },
+  defaultTreatment: 'off'
 };
 splitViews = [splitView];
 

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -498,7 +498,12 @@ declare namespace SplitIO {
      */
     configs: {
       [treatmentName: string]: string
-    }
+    },
+    /**
+     * The default treatment of the feature flag.
+     * @property {string} defaultTreatment
+     */
+    defaultTreatment: string,
   };
   /**
    * A promise that resolves to a feature flag view.


### PR DESCRIPTION
# JS Browser SDK

## What did you accomplish?

- Update JS-commons dependency.
- Vulnerability fixes of transitive dependencies.
- Add defaultTreatment to SplitView.

## How do we test the changes introduced in this PR?

Integration tests

## Extra Notes

Related to https://github.com/splitio/javascript-commons/issues/225