### PR TITLE
[Breaking change] Remove `LocalhostFromObject` export

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
       ],
       "rules": {
         "no-restricted-syntax": ["error", "ForOfStatement", "ForInStatement", "ArrayPattern"],
-        "compat/compat": ["error", "defaults, ie 10"],
+        "compat/compat": ["error", "defaults"],
         "no-throw-literal": "error",
         "import/no-default-export": "error",
         "import/no-self-import": "error",

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@
  - BREAKING CHANGES:
     - Removed internal ponyfills for the `Map` and `Set` global objects, dropping support for IE and other outdated browsers. The SDK now requires the runtime environment to support these features natively or provide a polyfill.
     - Removed the deprecated `GoogleAnalyticsToSplit` and `SplitToGoogleAnalytics` pluggable integration modules, along with the related interfaces in the TypeScript definitions.
-    - Removed the `LocalhostFromObject` export from the "slim" entrypoint (`import { LocalhostFromObject } from '@splitsoftware/splitio-browserjs'`). It is no longer necessary to manually import and configure it in the `sync.localhostMode` option to enable localhost mode.
+    - Removed the `LocalhostFromObject` export from the default import (`import { LocalhostFromObject } from '@splitsoftware/splitio-browserjs'`). It is no longer necessary to manually import and configure it in the `sync.localhostMode` option to enable localhost mode.
 
 0.15.0 (September 13, 2024)
  - Updated @splitsoftware/splitio-commons package to version 1.17.0 that includes minor updates:
@@ -71,7 +71,7 @@
 
 0.9.4 (May 4, 2023)
  - Updated some transitive dependencies for vulnerability fixes.
- - Bugfixing - Updated `unfetch` package as a runtime dependency, required when using the "full" entrypoint (`import { SplitFactory } from '@splitsoftware/splitio-browserjs/full'`).
+ - Bugfixing - Updated `unfetch` package as a runtime dependency, required when using the "full" import (`import { SplitFactory } from '@splitsoftware/splitio-browserjs/full'`).
 
 0.9.3 (March 20, 2023)
  - Updated @splitsoftware/splitio-commons package to version 1.8.1 that includes minor improvements.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@
  - BREAKING CHANGES:
     - Removed internal ponyfills for the `Map` and `Set` global objects, dropping support for IE and other outdated browsers. The SDK now requires the runtime environment to support these features natively or provide a polyfill.
     - Removed the deprecated `GoogleAnalyticsToSplit` and `SplitToGoogleAnalytics` pluggable integration modules, along with the related interfaces in the TypeScript definitions.
+    - Removed the `LocalhostFromObject` export from the "slim" entrypoint (`import { LocalhostFromObject } from '@splitsoftware/splitio-browserjs'`). It is no longer necessary to manually import and configure it in the `sync.localhostMode` option to enable localhost mode.
 
 0.15.0 (September 13, 2024)
  - Updated @splitsoftware/splitio-commons package to version 1.17.0 that includes minor updates:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio-commons": "2.0.0-rc.2",
+        "@splitsoftware/splitio-commons": "2.0.0-rc.3",
         "tslib": "^2.3.1",
         "unfetch": "^4.2.0"
       },
@@ -1501,9 +1501,9 @@
       "dev": true
     },
     "node_modules/@splitsoftware/splitio-commons": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.2.tgz",
-      "integrity": "sha512-QfCg2D5hjg+iuQiEYpsMEjtJ/dcYUsbcXJbvj7BH9t9DfVEplCv09oJcsC6CTFTSeA958y7yqe2EvTy/HVSM5g==",
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.3.tgz",
+      "integrity": "sha512-XkDbULWBg6nw061b4Vc425JyrpDe5nSypoScO4eVsFbgcCqUPlGbr+s9bfriwNFyZe2Q29ijIlyGM06TCt27kQ==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -10577,9 +10577,9 @@
       "dev": true
     },
     "@splitsoftware/splitio-commons": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.2.tgz",
-      "integrity": "sha512-QfCg2D5hjg+iuQiEYpsMEjtJ/dcYUsbcXJbvj7BH9t9DfVEplCv09oJcsC6CTFTSeA958y7yqe2EvTy/HVSM5g==",
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.0.0-rc.3.tgz",
+      "integrity": "sha512-XkDbULWBg6nw061b4Vc425JyrpDe5nSypoScO4eVsFbgcCqUPlGbr+s9bfriwNFyZe2Q29ijIlyGM06TCt27kQ==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "bugs": "https://github.com/splitio/javascript-browser-client/issues",
   "homepage": "https://github.com/splitio/javascript-browser-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio-commons": "2.0.0-rc.2",
+    "@splitsoftware/splitio-commons": "2.0.0-rc.3",
     "tslib": "^2.3.1",
     "unfetch": "^4.2.0"
   },

--- a/src/__tests__/consumer/browser_consumer.spec.js
+++ b/src/__tests__/consumer/browser_consumer.spec.js
@@ -32,8 +32,6 @@ const config = {
   }),
   sync: {
     impressionsMode: 'DEBUG',
-    // ignored
-    largeSegmentsEnabled: true,
   },
 };
 

--- a/src/__tests__/consumer/browser_consumer_partial.spec.js
+++ b/src/__tests__/consumer/browser_consumer_partial.spec.js
@@ -33,10 +33,6 @@ const config = {
     events: 'https://events.baseurl/impressionsSuite',
     telemetry: 'https://telemetry.baseurl/impressionsSuite'
   },
-  sync: {
-    // ignored
-    largeSegmentsEnabled: true,
-  },
 };
 
 tape('Browser Consumer Partial mode with pluggable storage', function (t) {

--- a/src/__tests__/offline/browser.spec.js
+++ b/src/__tests__/offline/browser.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import fetchMock from '../testUtils/fetchMock';
 import { url } from '../testUtils';
 import { SplitFactory, InLocalStorage } from '../../full';
-import { SplitFactory as SplitFactorySlim, LocalhostFromObject } from '../../';
+import { SplitFactory as SplitFactorySlim } from '../../';
 import { settingsFactory } from '../../settings';
 
 const settings = settingsFactory({ core: { key: 'facundo@split.io' } });
@@ -61,10 +61,6 @@ tape('Browser offline mode', function (assert) {
       readyTimeout: 0.001
     },
     features: originalFeaturesMap,
-    sync: {
-      // ignored
-      largeSegmentsEnabled: true,
-    }
   };
   const factory = SplitFactory(config);
   const manager = factory.manager();
@@ -94,24 +90,19 @@ tape('Browser offline mode', function (assert) {
 
   const factoriesReadyFromCache = [
     SplitFactory({ ...config, storage: InLocalStorage() }),
-    SplitFactorySlim({ ...config, storage: InLocalStorage(), sync: { localhostMode: LocalhostFromObject() } }) // slim factory requires localhostFromObject module
+    SplitFactorySlim({ ...config, storage: InLocalStorage() })
   ];
   const configs = [
-    { ...config, features: { ...config.features }, storage: InLocalStorage /* invalid */, sync: { localhostMode: LocalhostFromObject /* invalid */ } },
+    { ...config, features: { ...config.features }, storage: InLocalStorage /* invalid */ },
     { ...config },
     config,
   ];
-  const factoriesReady = [
+  const factories = [
     ...configs.map(config => SplitFactory(config)),
     ...factoriesReadyFromCache
   ];
-  const factoriesTimeout = [ // slim factory without a valid localhostFromObject module will timeout
-    SplitFactorySlim(config),
-    SplitFactorySlim({ ...config, sync: { localhostMode: LocalhostFromObject /* invalid */ } }),
-  ];
-  const factories = [...factoriesReady, ...factoriesTimeout];
 
-  let readyCount = 0, updateCount = 0, readyFromCacheCount = 0, timeoutCount = 0;
+  let readyCount = 0, updateCount = 0, readyFromCacheCount = 0;
 
   for (let i = 0; i < factories.length; i++) {
     const factory = factories[i], client = factory.client(), manager = factory.manager(), client2 = factory.client('other');
@@ -127,8 +118,7 @@ tape('Browser offline mode', function (assert) {
       updateCount++;
     });
     client.on(client.Event.SDK_READY_TIMED_OUT, () => {
-      assert.equal(factory.settings.sync.localhostMode, undefined);
-      timeoutCount++;
+      assert.fail('Should not emit SDK_READY_TIMED_OUT event');
     });
 
     const sdkReadyFromCache = (client) => () => {
@@ -253,8 +243,8 @@ tape('Browser offline mode', function (assert) {
       };
 
       // Update the features in all remaining factories except the last one
-      for (let i = 1; i < factoriesReady.length - 1; i++) {
-        factoriesReady[i].settings.features = factory.settings.features;
+      for (let i = 1; i < factories.length - 1; i++) {
+        factories[i].settings.features = factory.settings.features;
       }
 
       // Assigning a new object to the features property in the config object doesn't trigger an update
@@ -369,10 +359,9 @@ tape('Browser offline mode', function (assert) {
           assert.equal(sharedUpdateCount, 1, 'Shared client should have emitted SDK_UPDATE event once');
 
           // SDK events on other factory clients
-          assert.equal(readyCount, factoriesReady.length, 'Each factory client should have emitted SDK_READY event once');
-          assert.equal(updateCount, factoriesReady.length - 1, 'Each factory client except one should have emitted SDK_UPDATE event once');
+          assert.equal(readyCount, factories.length, 'Each factory client should have emitted SDK_READY event once');
+          assert.equal(updateCount, factories.length - 1, 'Each factory client except one should have emitted SDK_UPDATE event once');
           assert.equal(readyFromCacheCount, factoriesReadyFromCache.length * 2, 'The main and shared client of the factories with LOCALSTORAGE should have emitted SDK_READY_FROM_CACHE event');
-          assert.equal(timeoutCount, factoriesTimeout.length, 'The wrongly configured slim factories should have emitted SDK_READY_TIMED_OUT event');
 
           assert.end();
         });

--- a/src/full/splitFactory.ts
+++ b/src/full/splitFactory.ts
@@ -12,7 +12,7 @@ const platform = { getFetch, getEventSource, EventEmitter, now };
 
 /**
  * SplitFactory with pluggable modules for Browser.
- * Includes fetch polyfill out-of-the-box.
+ * It includes a `fetch` polyfill out-of-the-box.
  *
  * @param config configuration object used to instantiate the SDK
  * @param __updateModules optional function that lets redefine internal SDK modules. Use with

--- a/src/full/splitFactory.ts
+++ b/src/full/splitFactory.ts
@@ -12,7 +12,7 @@ const platform = { getFetch, getEventSource, EventEmitter, now };
 
 /**
  * SplitFactory with pluggable modules for Browser.
- * Includes localhost mode and fetch polyfill out-of-the-box.
+ * Includes fetch polyfill out-of-the-box.
  *
  * @param config configuration object used to instantiate the SDK
  * @param __updateModules optional function that lets redefine internal SDK modules. Use with

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,4 @@ export { ErrorLogger } from '@splitsoftware/splitio-commons/src/logger/browser/E
 export { WarnLogger } from '@splitsoftware/splitio-commons/src/logger/browser/WarnLogger';
 export { InfoLogger } from '@splitsoftware/splitio-commons/src/logger/browser/InfoLogger';
 export { DebugLogger } from '@splitsoftware/splitio-commons/src/logger/browser/DebugLogger';
-export { LocalhostFromObject } from '@splitsoftware/splitio-commons/src/sync/offline/LocalhostFromObject';
 export { PluggableStorage } from '@splitsoftware/splitio-commons/src/storages/pluggable';

--- a/src/platform/getModules.ts
+++ b/src/platform/getModules.ts
@@ -7,11 +7,11 @@ import { sdkClientMethodCSFactory } from '@splitsoftware/splitio-commons/src/sdk
 import { BrowserSignalListener } from '@splitsoftware/splitio-commons/src/listeners/browser';
 import { impressionObserverCSFactory } from '@splitsoftware/splitio-commons/src/trackers/impressionObserver/impressionObserverCS';
 import { pluggableIntegrationsManagerFactory } from '@splitsoftware/splitio-commons/src/integrations/pluggable';
-
 import { IPlatform, ISdkFactoryParams } from '@splitsoftware/splitio-commons/src/sdkFactory/types';
 import { ISettings } from '@splitsoftware/splitio-commons/src/types';
 import { CONSUMER_MODE, CONSUMER_PARTIAL_MODE, LOCALHOST_MODE } from '@splitsoftware/splitio-commons/src/utils/constants';
 import { createUserConsentAPI } from '@splitsoftware/splitio-commons/src/consent/sdkUserConsent';
+import { localhostFromObjectFactory } from '@splitsoftware/splitio-commons/src/sync/offline/LocalhostFromObject';
 
 let syncManagerStandaloneFactory: ISdkFactoryParams['syncManagerFactory'];
 let syncManagerSubmittersFactory: ISdkFactoryParams['syncManagerFactory'];
@@ -51,7 +51,7 @@ export function getModules(settings: ISettings, platform: IPlatform): ISdkFactor
   switch (settings.mode) {
     case LOCALHOST_MODE:
       modules.splitApiFactory = undefined;
-      modules.syncManagerFactory = settings.sync.localhostMode;
+      modules.syncManagerFactory = localhostFromObjectFactory;
       modules.SignalListener = undefined;
       break;
     case CONSUMER_MODE:

--- a/src/settings/full.ts
+++ b/src/settings/full.ts
@@ -4,9 +4,7 @@ import { validateRuntime } from '@splitsoftware/splitio-commons/src/utils/settin
 import { validateStorageCS } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/storage/storageCS';
 import { validatePluggableIntegrations } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/integrations/pluggable';
 import { validateLogger } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/logger/pluggableLogger';
-import { validateLocalhostWithDefault } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/localhost/builtin';
 import { validateConsent } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/consent';
-import { STANDALONE_MODE } from '@splitsoftware/splitio-commons/src/utils/constants';
 
 const params = {
   defaults,
@@ -15,15 +13,11 @@ const params = {
   storage: validateStorageCS,
   integrations: validatePluggableIntegrations,
   logger: validateLogger,
-  localhost: validateLocalhostWithDefault, // Full SplitFactory provides a default localhost module, except a valid one is provided
   consent: validateConsent,
 };
 
 export function settingsFactory(config: any) {
   const settings = settingsValidation(config, params);
-
-  // @ts-ignore, Override in localhost and consumer modes to emit SDK_READY event
-  if (settings.mode !== STANDALONE_MODE) settings.sync.largeSegmentsEnabled = false;
 
   return settings;
 }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -4,9 +4,7 @@ import { validateRuntime } from '@splitsoftware/splitio-commons/src/utils/settin
 import { validateStorageCS } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/storage/storageCS';
 import { validatePluggableIntegrations } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/integrations/pluggable';
 import { validateLogger } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/logger/pluggableLogger';
-import { validateLocalhost } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/localhost/pluggable';
 import { validateConsent } from '@splitsoftware/splitio-commons/src/utils/settingsValidation/consent';
-import { STANDALONE_MODE } from '@splitsoftware/splitio-commons/src/utils/constants';
 
 const params = {
   defaults,
@@ -15,15 +13,11 @@ const params = {
   storage: validateStorageCS,
   integrations: validatePluggableIntegrations,
   logger: validateLogger,
-  localhost: validateLocalhost, // Slim SplitFactory validates that the localhost module is passed in localhost mode
   consent: validateConsent,
 };
 
 export function settingsFactory(config: any) {
   const settings = settingsValidation(config, params);
-
-  // @ts-ignore, Override in localhost and consumer modes to emit SDK_READY event
-  if (settings.mode !== STANDALONE_MODE) settings.sync.largeSegmentsEnabled = false;
 
   return settings;
 }

--- a/src/splitFactory.ts
+++ b/src/splitFactory.ts
@@ -11,8 +11,7 @@ import { IBrowserSettings } from '../types/splitio';
 const platform = { getFetch, getEventSource, EventEmitter, now };
 
 /**
- * Slim SplitFactory with pluggable modules for Browser.
- * Doesn't include fetch ponyfill out-of-the-box.
+ * SplitFactory with pluggable modules for Browser.
  *
  * @param config configuration object used to instantiate the SDK
  * @param __updateModules optional function that lets redefine internal SDK modules. Use with

--- a/src/splitFactory.ts
+++ b/src/splitFactory.ts
@@ -12,7 +12,7 @@ const platform = { getFetch, getEventSource, EventEmitter, now };
 
 /**
  * Slim SplitFactory with pluggable modules for Browser.
- * Doesn't include localhost mode and fetch ponyfill out-of-the-box.
+ * Doesn't include fetch ponyfill out-of-the-box.
  *
  * @param config configuration object used to instantiate the SDK
  * @param __updateModules optional function that lets redefine internal SDK modules. Use with

--- a/ts-tests/index.ts
+++ b/ts-tests/index.ts
@@ -12,7 +12,7 @@
  */
 
 import { SplitFactory as SplitFactoryFull, InLocalStorage as InLocalStorageFull, DebugLogger as DebugLoggerFull, InfoLogger as InfoLoggerFull, WarnLogger as WarnLoggerFull, ErrorLogger as ErrorLoggerFull, PluggableStorage as PluggableStorageFull } from '@splitsoftware/splitio-browserjs/full';
-import { SplitFactory, InLocalStorage, DebugLogger, InfoLogger, WarnLogger, ErrorLogger, LocalhostFromObject, PluggableStorage } from '@splitsoftware/splitio-browserjs';
+import { SplitFactory, InLocalStorage, DebugLogger, InfoLogger, WarnLogger, ErrorLogger, PluggableStorage } from '@splitsoftware/splitio-browserjs';
 
 // Entry points must export the same objects
 let splitFactory = SplitFactory; splitFactory = SplitFactoryFull;
@@ -563,7 +563,6 @@ let fullBrowserSettings: SplitIO.IBrowserSettings = {
   sync: {
     splitFilters: splitFilters,
     impressionsMode: 'DEBUG',
-    localhostMode: LocalhostFromObject(),
     enabled: true,
     requestOptions: {
       getHeaderOverrides(context) { return { ...context.headers, 'header': 'value' }; },

--- a/types/full/index.d.ts
+++ b/types/full/index.d.ts
@@ -9,7 +9,7 @@ declare module JsSdk {
   /**
    * Full version of the Split.io SDK factory function.
    *
-   * Unlike the slim version, it doesn't require a 'fetch' polyfill to support old browsers @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#language-support}.
+   * It includes a `fetch` polyfill out-of-the-box. @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#language-support}.
    *
    * The settings parameter should be an object that complies with the SplitIO.IBrowserSettings.
    * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#configuration}

--- a/types/full/index.d.ts
+++ b/types/full/index.d.ts
@@ -10,7 +10,6 @@ declare module JsSdk {
    * Full version of the Split.io SDK factory function.
    *
    * Unlike the slim version, it doesn't require a 'fetch' polyfill to support old browsers @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#language-support}.
-   * and includes localhost mode out-of-the-box @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#localhost-mode}.
    *
    * The settings parameter should be an object that complies with the SplitIO.IBrowserSettings.
    * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#configuration}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,9 +7,7 @@ export = JsSdk;
 
 declare module JsSdk {
   /**
-   * Slim version of the Split.io SDK factory function.
-   *
-   * Recommended to use for bundle size reduction in production, since it doesn't include a 'fetch' polyfill out-of-the-box
+   * Split.io SDK factory function.
    *
    * The settings parameter should be an object that complies with the SplitIO.IBrowserSettings.
    * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#configuration}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,8 +9,7 @@ declare module JsSdk {
   /**
    * Slim version of the Split.io SDK factory function.
    *
-   * Recommended to use for bundle size reduction in production, since it doesn't include a 'fetch' polyfill and localhost mode out-of-the-box
-   * @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#localhost-mode}.
+   * Recommended to use for bundle size reduction in production, since it doesn't include a 'fetch' polyfill out-of-the-box
    *
    * The settings parameter should be an object that complies with the SplitIO.IBrowserSettings.
    * For more information read the corresponding article: @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#configuration}
@@ -59,12 +58,4 @@ declare module JsSdk {
    * @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#logging}
    */
   export function ErrorLogger(): SplitIO.ILogger;
-
-  /**
-   * Required to enable localhost mode when importing the SDK from the slim entry point of the library.
-   * It uses the mocked features map defined in the 'features' config object.
-   *
-   * @see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#localhost-mode}
-   */
-  export function LocalhostFromObject(): SplitIO.LocalhostFactory;
 }

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -91,7 +91,6 @@ interface ISettings {
     impressionsMode: SplitIO.ImpressionsMode,
     enabled: boolean,
     flagSpecVersion: string,
-    localhostMode?: SplitIO.LocalhostFactory,
     requestOptions?: {
       getHeaderOverrides?: (context: { headers: Record<string, string> }) => Record<string, string>
     },
@@ -225,25 +224,6 @@ interface ISharedSettings {
      * @default 'OPTIMIZED'
      */
     impressionsMode?: SplitIO.ImpressionsMode,
-    /**
-     * Defines the factory function to instantiate the SDK in localhost mode.
-     *
-     * NOTE: this is only required if using the slim entry point of the library to init the SDK in localhost mode.
-     *
-     * For more information see {@link https://help.split.io/hc/en-us/articles/360058730852-Browser-SDK#localhost-mode}
-     *
-     * Example:
-     * ```typescript
-     * SplitFactory({
-     *   ...
-     *   sync: {
-     *     localhostMode: LocalhostFromObject()
-     *   }
-     * })
-     * ```
-     * @property {Object} localhostMode
-     */
-    localhostMode?: SplitIO.LocalhostFactory
     /**
      * Controls the SDK continuous synchronization flags.
      *
@@ -472,11 +452,6 @@ declare namespace SplitIO {
     [featureName: string]: string | TreatmentWithConfig
   };
   /**
-   * Localhost types.
-   * @typedef {string} LocalhostType
-   */
-  type LocalhostType = 'LocalhostFromObject'
-  /**
    * Object with information about an impression. It contains the generated impression DTO as well as
    * complementary information around where and how it was generated in that way.
    * @typedef {Object} ImpressionData
@@ -623,14 +598,6 @@ declare namespace SplitIO {
      * @property {Object} wrapper
      */
     wrapper: Object
-  }
-  /**
-   * Localhost mode factory.
-   * Its interface details are not part of the public API.
-   */
-  type LocalhostFactory = {
-    readonly type: LocalhostType
-    (params: {}): {}
   }
   /**
    * Impression listener interface. This is the interface that needs to be implemented


### PR DESCRIPTION
# JS Browser SDK

## What did you accomplish?

Since the last refactors, the `LocalhostFromObject` module doesn't significantly impact bundle size, so it's included internally by the SDKs to favor usability.

## How do we test the changes introduced in this PR?

Unit tests.

## Extra Notes