### PR TITLE
Update SDK to support log level when `logger` is provided

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.5.1 (October 8, 2025)
+ - Bugfix - Updated @splitsoftware/splitio-commons package to version 2.7.1, which fixes the `debug` option to support log levels when the `logger` option is used.
+
 1.5.0 (October 7, 2025)
  - Added support for custom loggers: added `logger` configuration option and `factory.Logger.setLogger` method to allow the SDK to use a custom logger.
  - Updated @splitsoftware/splitio-commons package to version 2.7.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@splitsoftware/splitio-browserjs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-browserjs",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@splitsoftware/splitio-commons": "2.7.0",
+        "@splitsoftware/splitio-commons": "2.7.1",
         "tslib": "^2.3.1",
         "unfetch": "^4.2.0"
       },
@@ -1396,9 +1396,9 @@
       "dev": true
     },
     "node_modules/@splitsoftware/splitio-commons": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.7.0.tgz",
-      "integrity": "sha512-w2aemu5HNVQXX/tbmSuFjpWa/AjS+EBiH6ltHMqfg2MZMWayTFJbfjjQcudAVLR+vLjDw2DuCTp/xj3kKlcf5g==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.7.1.tgz",
+      "integrity": "sha512-7a4VVMczh0YKVRi35EhD0FOAEwzqfJRcCiKqLLhZCxAvrZBpE2khpGn8pOP+y6TefdPVtblW8GIku4O4r0KRdQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ioredis": "^4.28.0",
@@ -10493,9 +10493,9 @@
       "dev": true
     },
     "@splitsoftware/splitio-commons": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.7.0.tgz",
-      "integrity": "sha512-w2aemu5HNVQXX/tbmSuFjpWa/AjS+EBiH6ltHMqfg2MZMWayTFJbfjjQcudAVLR+vLjDw2DuCTp/xj3kKlcf5g==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@splitsoftware/splitio-commons/-/splitio-commons-2.7.1.tgz",
+      "integrity": "sha512-7a4VVMczh0YKVRi35EhD0FOAEwzqfJRcCiKqLLhZCxAvrZBpE2khpGn8pOP+y6TefdPVtblW8GIku4O4r0KRdQ==",
       "requires": {
         "@types/ioredis": "^4.28.0",
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-browserjs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Split SDK for JavaScript on Browser",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -59,7 +59,7 @@
   "bugs": "https://github.com/splitio/javascript-browser-client/issues",
   "homepage": "https://github.com/splitio/javascript-browser-client#readme",
   "dependencies": {
-    "@splitsoftware/splitio-commons": "2.7.0",
+    "@splitsoftware/splitio-commons": "2.7.1",
     "tslib": "^2.3.1",
     "unfetch": "^4.2.0"
   },

--- a/src/__tests__/logger/browser.spec.js
+++ b/src/__tests__/logger/browser.spec.js
@@ -64,10 +64,10 @@ tape('## E2E Logger Tests ##', assert => {
 
     const factory = SplitFactory({ ...minConfig, debug: 'INFO', logger: customLogger });
 
-    t.equal(factory.settings.log.options.logLevel, 'DEBUG', 'When combined with the `logger` option, any log level other than `NONE` (false) will be set to `DEBUG` (true)');
+    t.equal(factory.settings.log.options.logLevel, 'INFO');
 
     await factory.client().destroy();
-    t.true(customLogger.debug.calledWithMatch('splitio => '), 'should log messages with level DEBUG');
+    t.false(customLogger.debug.called, 'should not log messages with level DEBUG');
     t.true(customLogger.info.calledWithMatch('splitio => '), 'should log messages with level INFO');
 
     logSpy.resetHistory();

--- a/src/settings/defaults.ts
+++ b/src/settings/defaults.ts
@@ -2,7 +2,7 @@ import type SplitIO from '@splitsoftware/splitio-commons/types/splitio';
 import { LogLevels, isLogLevelString } from '@splitsoftware/splitio-commons/src/logger/index';
 import { CONSENT_GRANTED } from '@splitsoftware/splitio-commons/src/utils/constants';
 
-const packageVersion = '1.5.0';
+const packageVersion = '1.5.1';
 
 /**
  * In browser, the default debug level, can be set via the `localStorage.splitio_debug` item.


### PR DESCRIPTION
# JS Browser SDK

## What did you accomplish?

## How do we test the changes introduced in this PR?

## Extra Notes