### PR TITLE
fix: use namespace instead of module keyword for TypeScript 6/7 compatibility

### DIFF
--- a/types/full/index.d.ts
+++ b/types/full/index.d.ts
@@ -6,7 +6,7 @@
 
 export = JsSdk;
 
-declare module JsSdk {
+declare namespace JsSdk {
   /**
    * Full version of the Split.io SDK factory function.
    *

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@
 
 export = JsSdk;
 
-declare module JsSdk {
+declare namespace JsSdk {
   /**
    * Split.io SDK factory function.
    *


### PR DESCRIPTION
# JS Browser SDK

## What did you accomplish?

TypeScript 6+ (and tsgo from 7.0.0-dev.20260221.1) now errors on non-ambient:

> node_modules/.pnpm/@splitsoftware+splitio-browserjs@1.4.0/node_modules/@splitsoftware/splitio-browserjs/types/index.d.ts:9:16 - error TS1540: A 'namespace' declaration should not be declared using the 'module' keyword. Please use the 'namespace' keyword instead.              

This was deprecated in https://github.com/microsoft/TypeScript/pull/62876 (merged Dec 2025).

## How do we test the changes introduced in this PR?

The `module` and `namespace` keywords are functionally identical for
this use case, so this is a purely syntactic change with no runtime
or type-level impact.

## Extra Notes